### PR TITLE
Add As-Saadah skeleton with Next.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.next

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # LocalRepo
+
+This repository contains a skeleton Next.js project in the `as-saadah` folder.

--- a/as-saadah/README.md
+++ b/as-saadah/README.md
@@ -1,0 +1,3 @@
+# As-Saadah Website
+
+This is a skeleton Next.js project for the **As-Saadah** website. It contains minimal pages and Tailwind CSS configuration. Due to the environment restrictions, dependencies are listed but not installed.

--- a/as-saadah/components/Navbar.js
+++ b/as-saadah/components/Navbar.js
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export default function Navbar() {
+  return (
+    <nav className="fixed top-0 left-0 w-full backdrop-blur bg-white/70 shadow-sm flex items-center justify-between px-6 py-4">
+      <Link href="/" className="font-bold text-teal">As-Saadah</Link>
+      <div className="space-x-4">
+        <Link href="/about" className="hover:text-teal">About</Link>
+        <Link href="/blog" className="hover:text-teal">Blog</Link>
+        <Link href="/glossary" className="hover:text-teal">Glossary</Link>
+        <Link href="/contact" className="hover:text-teal">Contact</Link>
+      </div>
+    </nav>
+  )
+}

--- a/as-saadah/next.config.js
+++ b/as-saadah/next.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+module.exports = nextConfig

--- a/as-saadah/package.json
+++ b/as-saadah/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "as-saadah",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "tailwindcss": "^3.4.0",
+    "framer-motion": "^11.0.0",
+    "swiper": "^11.0.0",
+    "react-hook-form": "^7.0.0"
+  }
+}

--- a/as-saadah/pages/_app.js
+++ b/as-saadah/pages/_app.js
@@ -1,0 +1,5 @@
+import '@/styles/globals.css'
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/as-saadah/pages/about.js
+++ b/as-saadah/pages/about.js
@@ -1,0 +1,12 @@
+import Navbar from '@/components/Navbar'
+export default function About() {
+  return (
+    <>
+      <Navbar />
+      <div className="p-8">
+        <h1 className="text-3xl font-bold mb-4">About Us</h1>
+        <p>As-Saadah aims to blend spiritual knowledge with modern design to inspire hope and happiness.</p>
+      </div>
+    </>
+  )
+}

--- a/as-saadah/pages/blog/[slug].js
+++ b/as-saadah/pages/blog/[slug].js
@@ -1,0 +1,17 @@
+import { useRouter } from 'next/router'
+import Navbar from '@/components/Navbar'
+
+export default function Post() {
+  const { query } = useRouter()
+  const { slug } = query
+
+  return (
+    <>
+      <Navbar />
+      <div className="p-8">
+        <h1 className="text-3xl font-bold mb-4">{slug}</h1>
+        <p>Blog content coming soon...</p>
+      </div>
+    </>
+  )
+}

--- a/as-saadah/pages/blog/index.js
+++ b/as-saadah/pages/blog/index.js
@@ -1,0 +1,26 @@
+import Navbar from '@/components/Navbar'
+
+const posts = [
+  { title: 'First Article', slug: 'first-article' },
+  { title: 'Second Article', slug: 'second-article' }
+]
+
+export default function Blog() {
+  return (
+    <>
+      <Navbar />
+      <div className="p-8">
+        <h1 className="text-3xl font-bold mb-4">Blog</h1>
+        <ul className="list-disc pl-5">
+          {posts.map(post => (
+            <li key={post.slug} className="mb-2">
+              <a href={`/blog/${post.slug}`} className="text-teal hover:underline">
+                {post.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </>
+  )
+}

--- a/as-saadah/pages/contact.js
+++ b/as-saadah/pages/contact.js
@@ -1,0 +1,18 @@
+import Navbar from '@/components/Navbar'
+
+export default function Contact() {
+  return (
+    <>
+      <Navbar />
+      <div className="p-8">
+        <h1 className="text-3xl font-bold mb-4">Contact Us</h1>
+        <form className="flex flex-col max-w-md gap-4">
+          <input type="text" placeholder="Name" className="border p-2 rounded" />
+          <input type="email" placeholder="Email" className="border p-2 rounded" />
+          <textarea placeholder="Message" className="border p-2 rounded" />
+          <button className="bg-teal text-white px-4 py-2 rounded">Send</button>
+        </form>
+      </div>
+    </>
+  )
+}

--- a/as-saadah/pages/donations.js
+++ b/as-saadah/pages/donations.js
@@ -1,0 +1,14 @@
+import Navbar from '@/components/Navbar'
+
+export default function Donations() {
+  return (
+    <>
+      <Navbar />
+      <div className="p-8">
+        <h1 className="text-3xl font-bold mb-4">Support As-Saadah</h1>
+        <p className="mb-4">Your support helps us continue providing valuable content.</p>
+        <button className="bg-gold text-white px-4 py-2 rounded">Donate</button>
+      </div>
+    </>
+  )
+}

--- a/as-saadah/pages/glossary.js
+++ b/as-saadah/pages/glossary.js
@@ -1,0 +1,24 @@
+import Navbar from '@/components/Navbar'
+
+const terms = [
+  { term: 'Salaam', definition: 'Peace' },
+  { term: 'Dua', definition: 'Supplication or prayer' }
+]
+
+export default function Glossary() {
+  return (
+    <>
+      <Navbar />
+      <div className="p-8">
+        <h1 className="text-3xl font-bold mb-4">Glossary</h1>
+        <ul>
+          {terms.map(t => (
+            <li key={t.term} className="mb-2">
+              <strong>{t.term}:</strong> {t.definition}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </>
+  )
+}

--- a/as-saadah/pages/index.js
+++ b/as-saadah/pages/index.js
@@ -1,0 +1,17 @@
+import Head from 'next/head'
+import Navbar from '@/components/Navbar'
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>As-Saadah</title>
+      </Head>
+      <Navbar />
+      <main className="flex flex-col items-center justify-center text-center py-20">
+        <h1 className="text-4xl font-bold mb-4">Welcome to As-Saadah</h1>
+        <p className="max-w-xl">Transforming Lives, Inspiring Hope</p>
+      </main>
+    </>
+  )
+}

--- a/as-saadah/postcss.config.cjs
+++ b/as-saadah/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/as-saadah/styles/globals.css
+++ b/as-saadah/styles/globals.css
@@ -1,0 +1,8 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  background: linear-gradient(to bottom, #ffffff, #fff7f0);
+  font-family: 'Poppins', sans-serif;
+}

--- a/as-saadah/tailwind.config.cjs
+++ b/as-saadah/tailwind.config.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        teal: '#4DB6AC',
+        gold: '#FFD700',
+        spiritualGreen: '#3B945E'
+      }
+    }
+  },
+  plugins: []
+}


### PR DESCRIPTION
## Summary
- set up minimal Next.js project in `as-saadah`
- configure Tailwind CSS and global styles
- add navigation bar and several starter pages
- update repo README

## Testing
- `npx create-next-app@latest as-saadah` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6887be6916208323b920e86887f4180d